### PR TITLE
Remove temporary keyring before install completes

### DIFF
--- a/apt-bootstrap
+++ b/apt-bootstrap
@@ -107,15 +107,20 @@ class AptBootstrap(object):
         apt_pkg.config.set('APT::Install-Recommends',
                            str(self.recommends))
         apt_pkg.config.set('Dpkg::Options::', '--force-unsafe-io')
+
+        # Keyring configuration
+        self.target_keyring = os.path.join(
+            self.path, 'etc/apt/trusted.gpg.d/apt-bootstrap.gpg')
         if self.keyring is not None:
-            #apt_pkg.config.set('Dir::Etc::trusted', self.keyring)
-            keyring_path = os.path.join(self.path, 'etc/apt/trusted.gpg.d',
-                                        os.path.basename(self.keyring))
-            if not os.path.exists(keyring_path):
-                shutil.copy(self.keyring, keyring_path)
+            if not os.path.exists(self.target_keyring):
+                print('Installing temporary keyring',
+                      self.target_keyring)
+                shutil.copy(self.keyring, self.target_keyring)
         else:
             # If no keyring is provided, package verification will fail
             apt_pkg.config.set('APT::Get::AllowUnauthenticated', 'true')
+
+        # Debug configuration
         if self.debug:
             apt_pkg.config.set('Debug::pkgDepCache::AutoInstall', 'true')
             apt_pkg.config.set('Debug::pkgProblemResolver', 'true')
@@ -450,6 +455,11 @@ class AptBootstrap(object):
 
         self.stage1()
         self.stage2()
+
+        # Remove temporary keyring
+        if os.path.exists(self.target_keyring):
+            print('Removing temporary keyring', self.target_keyring)
+            os.unlink(self.target_kerying)
 
         print('Installation complete')
 


### PR DESCRIPTION
The purpose of the specified keyring is to bootstrap the authentication
process. It's assumed that the target will install a package that
contains the standard keyring used at runtime. Name the temporary
keyring something that's unlikely to conflict with an installed keyring
and remove it before the install completes.