### PR TITLE
Create /var/lib/dpkg/available file

### DIFF
--- a/apt-bootstrap
+++ b/apt-bootstrap
@@ -99,6 +99,13 @@ class AptBootstrap(object):
             with open(self.dpkg_status, 'w') as f:
                 pass
 
+        # Satisfy runtime by creating dpkg available file. Apparently
+        # dpkg doesn't do this by itself, but debootstrap does.
+        dpkg_available = os.path.join(self.path,
+                                      'var/lib/dpkg/available')
+        with open(dpkg_available, 'a'):
+            pass
+
         # Setup configuration
         apt_pkg.config.set('APT::Architecture', self.arch)
         apt_pkg.config.set('Dir', self.path)


### PR DESCRIPTION
Apparently this is needed at runtime but dpkg doesn't create it.
debootstrap also creates this file.